### PR TITLE
fix typo in documentation

### DIFF
--- a/docs/development/git_workflow.rst
+++ b/docs/development/git_workflow.rst
@@ -138,7 +138,7 @@ Installing TARDIS in develop mode
 ---------------------------------
 
 TARDIS is designed so that it can generally be used directly out of the source
-tree by using ``import `` when running Python in the source of an
+tree by using ``import`` when running Python in the source of an
 TARDIS repository clone.
 
 #. Install TARDIS_ in develop mode::


### PR DESCRIPTION
There was an typo in git  workflow develop mode fixed
```md
``import `` to ``import`` as sphinx supports.
```
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
``import `` to ``import`` as sphinx supports.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested  by **preview changes**

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
